### PR TITLE
Adapting to stable version of ESP-IDF

### DIFF
--- a/dns_hijack_srv.c
+++ b/dns_hijack_srv.c
@@ -2,7 +2,6 @@
 #include <sys/param.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "esp_netif.h"
 #include "esp_log.h"
 #include "esp_event.h"
 


### PR DESCRIPTION
Hello Mr. Alija Bobija,
Thank you for creating excellent library fro ESP32.

I found that I need to omit including ```esp_netif.h``` in order to build your library under stable version of  ESP-IDF, such as version 3.3.1.<br>
And, I believe this header file is also not necessary if your library is compiled using latest version of ESP-IDF. 

Could you please consider to merge this patch?

Best regards,
Hiroshi Murayama